### PR TITLE
feat: support dynamically match pod label with request header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,54 +1,8 @@
+Lepton:
 
-
-<h1 align="center">
-    <img src="https://docs.solo.io/gloo-edge/master/img/Gloo-01.png" alt="Gloo Edge" width="200" height="155">
-  <br>
-  An Envoy-Powered API Gateway
-</h1>
-
-Gloo Edge is a feature-rich, Kubernetes-native ingress controller, and next-generation API gateway. Gloo Edge is exceptional in its function-level routing; its support for legacy apps, microservices and serverless; its discovery capabilities; its numerous features; and its tight integration with leading open-source projects. Gloo Edge is uniquely designed to support hybrid applications, in which multiple technologies, architectures, protocols, and clouds can coexist. 
-
-
-[**Installation**](https://gloo.solo.io/installation/) &nbsp; |
-&nbsp; [**Documentation**](https://gloo.solo.io) &nbsp; |
-&nbsp; [**Blog**](https://www.solo.io/blog/?category=gloo) &nbsp; |
-&nbsp; [**Slack**](https://slack.solo.io) &nbsp; |
-&nbsp; [**Twitter**](https://twitter.com/soloio_inc) |
-&nbsp; [**Enterprise Trial**](https://www.solo.io/products/gloo/#enterprise-trial)
-
-<BR><center><img src="https://docs.solo.io/gloo-edge/master/img/gloo-architecture-envoys.png" alt="Gloo Edge Architecture" width="906"></center>
-
-## Summary
-
-- [**Using Gloo Edge**](#using-gloo-edge)
-- [**What makes Gloo Edge unique**](#what-makes-gloo-edge-unique)
-
-
-## Using Gloo Edge
-- **Kubernetes ingress controller**: Gloo Edge can function as a feature-rich ingress controller, built on top of the Envoy Proxy. 
-- **Next-generation API gateway** : Gloo Edge provides a long list of API gateway features, including rate limiting, circuit breaking, retries, caching, external authentication and authorization, transformation, service-mesh integration, and security. 
-- **Hybrid apps**: Gloo Edge creates applications that route to backends implemented as microservices, serverless functions, and legacy apps. This feature can help users to gradually migrate from their legacy code to microservices and serverless; can let users add new functionalities using cloud-native technologies while maintaining their legacy codebase; can be used in cases where different teams in an organization choose different architectures; and more. See [here](https://www.solo.io/hybrid-app) for more on the Hybrid App paradigm. 
-
-
-## What makes Gloo Edge unique
-- **Function-level routing allows integration of legacy applications, microservices and serverless**: Gloo Edge can route requests directly to _functions_, which can be a serverless function call (e.g. Lambda, Google Cloud Function, OpenFaaS function, etc.), an API call on a microservice or a legacy service (e.g. a REST API call, OpenAPI operation, XML/SOAP request etc.), or publishing to a message queue (e.g. NATS, AMQP, etc.). This unique ability is what makes Gloo Edge the only API gateway that supports hybrid apps, as well as the only one that does not tie the user to a specific paradigm. 
-- **Gloo Edge incorporates vetted open-source projects to provide broad functionality**: Gloo Edge support high-quality features by integrating with top open-source projects, including gRPC, GraphQL, OpenTracing, NATS and more. Gloo Edge's architecture allows rapid integration of future popular open-source projects as they emerge. 
-- **Full automated discovery lets users move fast**: Upon launch, Gloo Edge creates a catalog of all available destinations, and continuously maintains it up to date. This takes the responsibility for 'bookkeeping' away from the developers, and guarantees that new feature become available as soon as they are ready. Gloo Edge discovers across IaaS, PaaS and FaaS providers, as well as Swagger, gRPC, and GraphQL. 
-- **Gloo Edge integrates intimately with the user's environment**: with Gloo Edge, users are free to choose their favorite tools for scheduling (such as K8s, Nomad, OpenShift, etc), persistence (K8s, Consul, etcd, etc) and security (K8s, Vault). 
-
-
-## Next Steps
-- Join us on our Slack channel: [https://slack.solo.io/](https://slack.solo.io/)
-- Follow us on Twitter: [https://twitter.com/soloio_inc](https://twitter.com/soloio_inc)
-- Check out the docs: [https://gloo.solo.io](https://gloo.solo.io)
-- Check out the code and contribute: [Contribution Guide](CONTRIBUTING.md)
-- Contribute to the [Docs](docs/)
-
-### Thanks
-
-**Gloo Edge** would not be possible without the valuable open-source work of projects in the community. We would like to extend a special thank-you to [Envoy](https://www.envoyproxy.io).
-
-
-# Security
-
-*Reporting security issues:* We take Gloo Edge's security very seriously. If you've found a security issue or a potential security issue in Gloo Edge, please DO NOT file a public Github issue, instead send your report privately to [security@solo.io](mailto:security@solo.io).
+Release:
+```
+IMAGE_REPO="public.ecr.aws/n0k2r8k8/gloo" VERSION="0.0.1-alpha.1" GOARCH=amd64 make gloo-docker
+aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/leptonai
+docker push public.ecr.aws/n0k2r8k8/gloo/gloo:0.0.1-alpha.1
+```

--- a/projects/gloo/pkg/translator/endpoints.go
+++ b/projects/gloo/pkg/translator/endpoints.go
@@ -1,6 +1,8 @@
 package translator
 
 import (
+	"strings"
+
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_config_endpoint_v3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	structpb "github.com/golang/protobuf/ptypes/struct"
@@ -154,13 +156,14 @@ func getLbMetadata(upstream *v1.Upstream, labels map[string]string, zeroValue st
 		}
 	}
 
-	if labels != nil {
-		for k, v := range labels {
-			labelsStruct.GetFields()[k] = &structpb.Value{
-				Kind: &structpb.Value_StringValue{
-					StringValue: v,
-				},
-			}
+	for k, v := range labels {
+		if strings.HasPrefix(v, headerToMetadataSelectorValuePrefix) {
+			continue
+		}
+		labelsStruct.GetFields()[k] = &structpb.Value{
+			Kind: &structpb.Value_StringValue{
+				StringValue: v,
+			},
 		}
 	}
 

--- a/projects/gloo/pkg/translator/route_config.go
+++ b/projects/gloo/pkg/translator/route_config.go
@@ -9,9 +9,11 @@ import (
 	"unicode"
 
 	"github.com/solo-io/gloo/projects/gloo/pkg/plugins/dynamic_forward_proxy"
+	"google.golang.org/protobuf/types/known/anypb"
 
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_config_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	envoy_header_to_metadata_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/header_to_metadata/v3"
 	envoy_type_matcher_v3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	"github.com/golang/protobuf/ptypes/wrappers"
 	errors "github.com/rotisserie/eris"
@@ -49,6 +51,9 @@ var (
 	PathEndsWithInvalidCharactersError = func(s, invalid string) error {
 		return errors.Errorf("path [%s] cannot end with [%s]", s, invalid)
 	}
+
+	// for dynamically performing subsetting
+	headerToMetadataSelectorValuePrefix = "$FromHeader:"
 )
 
 var (
@@ -174,6 +179,7 @@ func (h *httpRouteConfigurationTranslator) envoyRoutes(
 
 	for i := range out {
 		h.setAction(params, routeReport, in, out[i])
+		setHeaderToMetadataFilter(in, out[i])
 		validateEnvoyRoute(out[i], routeReport)
 	}
 
@@ -448,6 +454,77 @@ func (h *httpRouteConfigurationTranslator) setRouteAction(params plugins.RoutePa
 		return nil
 	}
 	return errors.Errorf("unknown upstream destination type")
+}
+
+// addMetadataToHeaderMapping tries to identify how request header name maps to endpoint metadata key, so that envoy will route requests
+// with the header value to corresponding endpoint with same metadata value, using Envoy header_to_metadata http filter and subset LB
+func AddMetadataToHeaderMapping(endpointMetadataKeyToHeader map[string]string, literalConfig map[string]string) {
+	for endpointMetadataKey, v := range literalConfig {
+		endpointMetadataKey = strings.TrimSpace(endpointMetadataKey)
+		if endpointMetadataKey == "" {
+			continue
+		}
+		v = strings.TrimSpace(v)
+		fromHeaderName := strings.TrimSpace(strings.TrimPrefix(v, headerToMetadataSelectorValuePrefix))
+		if fromHeaderName == v || fromHeaderName == "" {
+			continue
+		}
+		endpointMetadataKeyToHeader[endpointMetadataKey] = fromHeaderName
+	}
+}
+
+func NewMetadataToHeaderConfig(action *v1.RouteAction) *envoy_header_to_metadata_v3.Config {
+	if action == nil {
+		return nil
+	}
+	endpointMetadataKeyToHeader := make(map[string]string)
+	switch dest := action.GetDestination().(type) {
+	case *v1.RouteAction_Single:
+		AddMetadataToHeaderMapping(endpointMetadataKeyToHeader, dest.Single.GetSubset().GetValues())
+	case *v1.RouteAction_Multi:
+		for _, weightedDest := range dest.Multi.GetDestinations() {
+			dst := weightedDest.GetDestination()
+			AddMetadataToHeaderMapping(endpointMetadataKeyToHeader, dst.GetSubset().GetValues())
+		}
+	default: // other actions are not applicable
+	}
+
+	if len(endpointMetadataKeyToHeader) == 0 {
+		return nil
+	}
+	config := &envoy_header_to_metadata_v3.Config{}
+	for k, h := range endpointMetadataKeyToHeader {
+		config.RequestRules = append(config.RequestRules, &envoy_header_to_metadata_v3.Config_Rule{
+			Header: h,
+			OnHeaderPresent: &envoy_header_to_metadata_v3.Config_KeyValuePair{
+				Key:               k,
+				Type:              envoy_header_to_metadata_v3.Config_STRING,
+				MetadataNamespace: EnvoyLb,
+			},
+			OnHeaderMissing: nil,
+			Remove:          false,
+		})
+	}
+	return config
+}
+
+func setHeaderToMetadataFilter(route *v1.Route, out *envoy_config_route_v3.Route) {
+	if route == nil {
+		return
+	}
+	config := NewMetadataToHeaderConfig(route.GetRouteAction())
+	if config == nil {
+		return
+	}
+
+	if out.GetTypedPerFilterConfig() == nil {
+		out.TypedPerFilterConfig = make(map[string]*anypb.Any)
+	}
+	configAny, err := anypb.New(config)
+	if err != nil {
+		return
+	}
+	out.TypedPerFilterConfig[HTTPHeaderToMetadata] = configAny
 }
 
 func (h *httpRouteConfigurationTranslator) setWeightedClusters(params plugins.RouteParams, multiDest *v1.MultiDestination, out *envoy_config_route_v3.RouteAction, routeReport *validationapi.RouteReport, routeName string) error {

--- a/projects/gloo/pkg/translator/route_config.go
+++ b/projects/gloo/pkg/translator/route_config.go
@@ -462,12 +462,16 @@ func AddMetadataToHeaderMapping(endpointMetadataKeyToHeader map[string]string, l
 	for endpointMetadataKey, v := range literalConfig {
 		endpointMetadataKey = strings.TrimSpace(endpointMetadataKey)
 		if endpointMetadataKey == "" {
+			Logger.Errorf("endpoint subset config key should not be empty")
 			continue
 		}
 		v = strings.TrimSpace(v)
 		fromHeaderName := strings.TrimSpace(strings.TrimPrefix(v, headerToMetadataSelectorValuePrefix))
-		if fromHeaderName == v || fromHeaderName == "" {
+		if fromHeaderName == v {
 			continue
+		}
+		if fromHeaderName == "" {
+			Logger.Errorf("endpoint subset header name should not be empty, key: %s", endpointMetadataKey)
 		}
 		endpointMetadataKeyToHeader[endpointMetadataKey] = fromHeaderName
 	}
@@ -522,6 +526,7 @@ func setHeaderToMetadataFilter(route *v1.Route, out *envoy_config_route_v3.Route
 	}
 	configAny, err := anypb.New(config)
 	if err != nil {
+		Logger.Errorf("failed to convert config to protobuf any type")
 		return
 	}
 	out.TypedPerFilterConfig[HTTPHeaderToMetadata] = configAny

--- a/projects/gloo/pkg/translator/route_config_test.go
+++ b/projects/gloo/pkg/translator/route_config_test.go
@@ -1,13 +1,19 @@
 package translator_test
 
 import (
+	"reflect"
+	"slices"
 	"strconv"
 	"strings"
+	"testing"
 
+	envoy_header_to_metadata_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/header_to_metadata/v3"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 	"github.com/solo-io/gloo/projects/gloo/pkg/translator"
+	"github.com/stretchr/testify/assert"
 )
 
 var _ = Describe("Route Configs", func() {
@@ -90,3 +96,130 @@ var _ = Describe("Route Configs", func() {
 		Entry("invalid", "some/site[hello", false),
 	)
 })
+
+func Test_addMetadataToHeaderMapping(t *testing.T) {
+	tests := []struct {
+		literalConfig               map[string]string
+		endpointMetadataKeyToHeader map[string]string
+		expect                      map[string]string
+	}{
+		{
+			// simple literal config case, no dynamic loading expected
+			literalConfig: map[string]string{
+				"version": "2",
+			},
+			endpointMetadataKeyToHeader: map[string]string{},
+			expect:                      map[string]string{},
+		},
+		{
+			// simple dynamic config case, no dynamic loading expected
+			literalConfig: map[string]string{
+				"version": "$FromHeader:x-version",
+			},
+			endpointMetadataKeyToHeader: map[string]string{},
+			expect:                      map[string]string{"version": "x-version"},
+		},
+		{
+			// append behavior
+			literalConfig: map[string]string{
+				"version": "$FromHeader: x-version",
+			},
+			endpointMetadataKeyToHeader: map[string]string{"a": "b"},
+			expect:                      map[string]string{"a": "b", "version": "x-version"},
+		},
+		{
+			// forbit empty header name
+			literalConfig: map[string]string{
+				"version": "$FromHeader:",
+			},
+			endpointMetadataKeyToHeader: map[string]string{"a": "b"},
+			expect:                      map[string]string{"a": "b"},
+		},
+	}
+	for _, tt := range tests {
+		translator.AddMetadataToHeaderMapping(tt.endpointMetadataKeyToHeader, tt.literalConfig)
+		assert.Equal(t, tt.endpointMetadataKeyToHeader, tt.expect)
+	}
+}
+
+func subset(m map[string]string) *v1.Subset {
+	return &v1.Subset{
+		Values: m,
+	}
+}
+
+func sort(t *testing.T, c *envoy_header_to_metadata_v3.Config) {
+	if c == nil {
+		return
+	}
+	slices.SortFunc(c.RequestRules, func(a, b *envoy_header_to_metadata_v3.Config_Rule) int {
+		if a == nil {
+			t.Fatal("should not have nil rule")
+		}
+		if a.Header < b.Header {
+			return -1
+		}
+		return 1
+	})
+}
+
+func TestNewMetadataToHeaderConfig(t *testing.T) {
+	tests := []struct {
+		action *v1.RouteAction
+		want   *envoy_header_to_metadata_v3.Config
+	}{
+		{
+			action: nil,
+			want:   nil,
+		},
+		{
+			action: &v1.RouteAction{Destination: &v1.RouteAction_Single{
+				Single: &v1.Destination{Subset: subset(map[string]string{"version": "2"})},
+			}},
+			want: nil,
+		},
+		{
+			action: &v1.RouteAction{Destination: &v1.RouteAction_Single{
+				Single: &v1.Destination{Subset: subset(map[string]string{"version": "$FromHeader:x-version", "a": "$FromHeader:b"})},
+			}},
+			want: &envoy_header_to_metadata_v3.Config{RequestRules: []*envoy_header_to_metadata_v3.Config_Rule{
+				{Header: "x-version", Remove: false, OnHeaderPresent: &envoy_header_to_metadata_v3.Config_KeyValuePair{
+					MetadataNamespace: "envoy.lb", Type: 0, Key: "version",
+				}},
+				{Header: "b", Remove: false, OnHeaderPresent: &envoy_header_to_metadata_v3.Config_KeyValuePair{
+					MetadataNamespace: "envoy.lb", Type: 0, Key: "a",
+				}},
+			}},
+		},
+		{
+			action: &v1.RouteAction{Destination: &v1.RouteAction_Multi{
+				Multi: &v1.MultiDestination{
+					Destinations: []*v1.WeightedDestination{
+						{Destination: &v1.Destination{Subset: subset(map[string]string{"version": "$FromHeader: x-version", "a": "$FromHeader:b"})}},
+						{Destination: &v1.Destination{Subset: subset(map[string]string{"c": "$FromHeader:d", "a": "$FromHeader:b"})}},
+					},
+				},
+			}},
+			want: &envoy_header_to_metadata_v3.Config{RequestRules: []*envoy_header_to_metadata_v3.Config_Rule{
+				{Header: "x-version", Remove: false, OnHeaderPresent: &envoy_header_to_metadata_v3.Config_KeyValuePair{
+					MetadataNamespace: "envoy.lb", Type: 0, Key: "version",
+				}},
+				{Header: "b", Remove: false, OnHeaderPresent: &envoy_header_to_metadata_v3.Config_KeyValuePair{
+					MetadataNamespace: "envoy.lb", Type: 0, Key: "a",
+				}},
+				{Header: "d", Remove: false, OnHeaderPresent: &envoy_header_to_metadata_v3.Config_KeyValuePair{
+					MetadataNamespace: "envoy.lb", Type: 0, Key: "c",
+				}},
+			}},
+		},
+	}
+	for _, tt := range tests {
+		got := translator.NewMetadataToHeaderConfig(tt.action)
+		sort(t, got)
+		sort(t, tt.want)
+
+		if !reflect.DeepEqual(got, tt.want) {
+			t.Errorf("NewMetadataToHeaderConfig() = %v, want %v", got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
mainly for regional routing, replica-based routing can also benefit from it:

for request with header "x-lepton-ingress-region: us-east-1", it will be only routed to pods with label "ingress.lepton.ai/region: us-east-1", dynamically (we don't need to define rule for every region);

in similar vein, we don't need to define a route for every replica name anymore after with this pr cc @ccding 